### PR TITLE
Fix Exception in AnimationController if disposed whilst actively animating

### DIFF
--- a/lib/dropdown_textfield.dart
+++ b/lib/dropdown_textfield.dart
@@ -473,6 +473,10 @@ class _DropDownTextFieldState extends State<DropDownTextField>
   void dispose() {
     if (widget.searchFocusNode == null) _searchFocusNode.dispose();
     if (widget.textFieldFocusNode == null) _textFieldFocusNode.dispose();
+    if (_controller.isAnimating) {
+      _controller.stop();
+    } 
+    _controller.dispose();
     _cnt.dispose();
     super.dispose();
   }


### PR DESCRIPTION
- When disposing of the dropdown, base code explicitly doesn't dispose of the underlying AnimationController
- If the AnimationController is currently animating when disposed, a ticker will still be active which raises an exception
- Fix to stop any current animations and dispose of the AnimationController when the dropdown is disposed