### PR TITLE
feat: add closeOnTapOutside parameter, which lets the dropdown to stay opened even when the user taps outside of it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ You need to use `SingleValueDropDownController` for single dropdown and `MultiVa
 - **submitButtonTextStyle**: Text style for the multi-dropdown submit button.
 - **listTextStyle**: Text style for dropdown list items.
 - **checkBoxProperty**: Customizes the properties of multiple checkboxes.
+- **closeOnTapOutside**: Set to `false` if the dropdown shouldn't close when the user taps outside of it.
 
 
 ## Contributing

--- a/lib/dropdown_textfield.dart
+++ b/lib/dropdown_textfield.dart
@@ -83,7 +83,7 @@ class DropDownTextField extends StatefulWidget {
       this.autovalidateMode,
       this.boxDecoration,
       this.boxMargin,
-      this.closeDropdownOnOutsideClick = true})
+      this.closeOnTapOutside = true})
       : assert(
           !(initialValue != null && controller != null),
           "you cannot add both initialValue and singleController,\nset initial value using controller \n\tEg: SingleValueDropDownController(data:initial value) ",
@@ -133,7 +133,7 @@ class DropDownTextField extends StatefulWidget {
     this.autovalidateMode,
     this.boxDecoration,
     this.boxMargin,
-    this.closeDropdownOnOutsideClick = true,
+    this.closeOnTapOutside = true,
   })  : assert(initialValue == null || controller == null,
             "you cannot add both initialValue and multiController\nset initial value using controller\n\tMultiValueDropDownController(data:initial value)"),
         assert(
@@ -259,8 +259,8 @@ class DropDownTextField extends StatefulWidget {
   ///customize checkbox property
   final CheckBoxProperty? checkBoxProperty;
 
-  ///by setting closeDropdownOnOutsideClick=true, the dropdown will be closed when the user clicks outside of the dropdown
-  final bool closeDropdownOnOutsideClick;
+  ///by setting closeOnTapOutside=true, the dropdown will be closed when the user clicks outside of the dropdown
+  final bool closeOnTapOutside;
 
   @override
   _DropDownTextFieldState createState() => _DropDownTextFieldState();
@@ -573,7 +573,7 @@ class _DropDownTextFieldState extends State<DropDownTextField>
             style: widget.textStyle,
             enabled: widget.isEnabled,
             readOnly: widget.readOnly,
-            onTapOutside: widget.closeDropdownOnOutsideClick ? (event) {
+            onTapOutside: widget.closeOnTapOutside ? (event) {
               final RenderObject? renderObject =
                   overlayKey.currentContext?.findRenderObject();
               if (renderObject is RenderBox) {

--- a/lib/dropdown_textfield.dart
+++ b/lib/dropdown_textfield.dart
@@ -322,16 +322,16 @@ class _DropDownTextFieldState extends State<DropDownTextField>
     _heightFactor = _controller.drive(_easeInTween);
     _searchWidgetHeight = 60;
     _hintText = "Select Item";
+      _searchFocusNode.addListener(() {
+      if (!_searchFocusNode.hasFocus &&
+          !_textFieldFocusNode.hasFocus &&
+          _isExpanded &&
+          !widget.isMultiSelection) {
+        _isExpanded = !_isExpanded;
+        hideOverlay();
+      }
+    });
     if(widget.closeDropdownOnOutsideClick) {    
-        _searchFocusNode.addListener(() {
-        if (!_searchFocusNode.hasFocus &&
-            !_textFieldFocusNode.hasFocus &&
-            _isExpanded &&
-            !widget.isMultiSelection) {
-          _isExpanded = !_isExpanded;
-          hideOverlay();
-        }
-      });
       _textFieldFocusNode.addListener(() {
         if (!_searchFocusNode.hasFocus &&
             !_textFieldFocusNode.hasFocus &&

--- a/lib/dropdown_textfield.dart
+++ b/lib/dropdown_textfield.dart
@@ -331,22 +331,20 @@ class _DropDownTextFieldState extends State<DropDownTextField>
         hideOverlay();
       }
     });
-    if(widget.closeDropdownOnOutsideClick) {    
-      _textFieldFocusNode.addListener(() {
-        if (!_searchFocusNode.hasFocus &&
-            !_textFieldFocusNode.hasFocus &&
-            _isExpanded) {
-          _isExpanded = !_isExpanded;
-          hideOverlay();
-          if (!widget.readOnly &&
-              widget.singleController?.dropDownValue?.name != _cnt.text) {
-            setState(() {
-              _cnt.clear();
-            });
-          }
+    _textFieldFocusNode.addListener(() {
+      if (!_searchFocusNode.hasFocus &&
+          !_textFieldFocusNode.hasFocus &&
+          _isExpanded) {
+        _isExpanded = !_isExpanded;
+        hideOverlay();
+        if (!widget.readOnly &&
+            widget.singleController?.dropDownValue?.name != _cnt.text) {
+          setState(() {
+            _cnt.clear();
+          });
         }
-      });
-    }
+      }
+    });
     widget.singleController?.addListener(() {
       if (widget.singleController?.dropDownValue == null) {
         clearFun();

--- a/lib/dropdown_textfield.dart
+++ b/lib/dropdown_textfield.dart
@@ -82,7 +82,8 @@ class DropDownTextField extends StatefulWidget {
       this.keyboardType,
       this.autovalidateMode,
       this.boxDecoration,
-      this.boxMargin})
+      this.boxMargin,
+      this.closeDropdownOnOutsideClick = true})
       : assert(
           !(initialValue != null && controller != null),
           "you cannot add both initialValue and singleController,\nset initial value using controller \n\tEg: SingleValueDropDownController(data:initial value) ",
@@ -132,6 +133,7 @@ class DropDownTextField extends StatefulWidget {
     this.autovalidateMode,
     this.boxDecoration,
     this.boxMargin,
+    this.closeDropdownOnOutsideClick = true,
   })  : assert(initialValue == null || controller == null,
             "you cannot add both initialValue and multiController\nset initial value using controller\n\tMultiValueDropDownController(data:initial value)"),
         assert(
@@ -257,6 +259,9 @@ class DropDownTextField extends StatefulWidget {
   ///customize checkbox property
   final CheckBoxProperty? checkBoxProperty;
 
+  ///by setting closeDropdownOnOutsideClick=true, the dropdown will be closed when the user clicks outside of the dropdown
+  final bool closeDropdownOnOutsideClick;
+
   @override
   _DropDownTextFieldState createState() => _DropDownTextFieldState();
 }
@@ -317,29 +322,31 @@ class _DropDownTextFieldState extends State<DropDownTextField>
     _heightFactor = _controller.drive(_easeInTween);
     _searchWidgetHeight = 60;
     _hintText = "Select Item";
-    _searchFocusNode.addListener(() {
-      if (!_searchFocusNode.hasFocus &&
-          !_textFieldFocusNode.hasFocus &&
-          _isExpanded &&
-          !widget.isMultiSelection) {
-        _isExpanded = !_isExpanded;
-        hideOverlay();
-      }
-    });
-    _textFieldFocusNode.addListener(() {
-      if (!_searchFocusNode.hasFocus &&
-          !_textFieldFocusNode.hasFocus &&
-          _isExpanded) {
-        _isExpanded = !_isExpanded;
-        hideOverlay();
-        if (!widget.readOnly &&
-            widget.singleController?.dropDownValue?.name != _cnt.text) {
-          setState(() {
-            _cnt.clear();
-          });
+    if(widget.closeDropdownOnOutsideClick) {    
+        _searchFocusNode.addListener(() {
+        if (!_searchFocusNode.hasFocus &&
+            !_textFieldFocusNode.hasFocus &&
+            _isExpanded &&
+            !widget.isMultiSelection) {
+          _isExpanded = !_isExpanded;
+          hideOverlay();
         }
-      }
-    });
+      });
+      _textFieldFocusNode.addListener(() {
+        if (!_searchFocusNode.hasFocus &&
+            !_textFieldFocusNode.hasFocus &&
+            _isExpanded) {
+          _isExpanded = !_isExpanded;
+          hideOverlay();
+          if (!widget.readOnly &&
+              widget.singleController?.dropDownValue?.name != _cnt.text) {
+            setState(() {
+              _cnt.clear();
+            });
+          }
+        }
+      });
+    }
     widget.singleController?.addListener(() {
       if (widget.singleController?.dropDownValue == null) {
         clearFun();
@@ -568,7 +575,7 @@ class _DropDownTextFieldState extends State<DropDownTextField>
             style: widget.textStyle,
             enabled: widget.isEnabled,
             readOnly: widget.readOnly,
-            onTapOutside: (event) {
+            onTapOutside: widget.closeDropdownOnOutsideClick ? (event) {
               final RenderObject? renderObject =
                   overlayKey.currentContext?.findRenderObject();
               if (renderObject is RenderBox) {
@@ -584,7 +591,7 @@ class _DropDownTextFieldState extends State<DropDownTextField>
                   _textFieldFocusNode.unfocus();
                 }
               }
-            },
+            } : null,
             onTap: () {
               _searchAutofocus = widget.searchAutofocus;
               if (!_isExpanded) {


### PR DESCRIPTION
This parameter prevents errors when using screen readers on web. The screen reader's interaction generates taps outside the dropdown when not intended, closing the dropdown before the user selects the wanted value.